### PR TITLE
unify resource detection procedure

### DIFF
--- a/src/gth/bssm_param.c
+++ b/src/gth/bssm_param.c
@@ -29,6 +29,7 @@
 #include "gth/gthprobdef.h"
 #include "gth/gthspeciestab.h"
 #include "gth/showbool.h"
+#include "libgenomethreader/findfile.h"
 
 /*
   This is a collection of functions associated with
@@ -451,42 +452,7 @@ GthBSSMParam* gth_bssm_param_load(const char *filename, GtError *err)
   if (gt_file_exists(filename))
     gt_str_append_cstr(path, filename);
   else {
-    if (strchr(filename, GT_PATH_SEPARATOR)) {
-      gt_error_set(err, "filename \"%s\" contains illegal symbol '%c': the "
-                        "path list specified by environment variable \"%s\" "
-                        "cannot be searched for it", filename,
-                        GT_PATH_SEPARATOR, BSSMENVNAME);
-      had_err = -1;
-    }
-    /* check for file path in environment variable */
-    if (!had_err)
-      had_err = gt_file_find_in_env(path, filename, BSSMENVNAME, err);
-    if (!had_err && !gt_str_length(path)) {
-      gt_error_set(err, "file \"%s\" not found in directory list specified "
-                        "by environment variable %s", filename, BSSMENVNAME);
-      had_err = -1;
-    }
-    if (!had_err) {
-      /* path found -> append filename */
-      gt_str_append_char(path, GT_PATH_SEPARATOR);
-      gt_str_append_cstr(path, filename);
-    }
-    else {
-      /* check for file path relative to binary */
-      int new_err = gt_file_find_exec_in_path(path, gt_error_get_progname(err),
-                                              NULL);
-      if (!new_err) {
-        gt_assert(gt_str_length(path));
-        gt_str_append_char(path, GT_PATH_SEPARATOR);
-        gt_str_append_cstr(path, "bssm");
-        gt_str_append_char(path, GT_PATH_SEPARATOR);
-        gt_str_append_cstr(path, filename);
-        if (gt_file_exists(gt_str_get(path))) {
-          gt_error_unset(err);
-          had_err = 0;
-        }
-      }
-    }
+    had_err = gth_find_file(filename, BSSMENVNAME, "bssm", path, err);
   }
 
   if (!had_err) {

--- a/src/libgenomethreader/findfile.c
+++ b/src/libgenomethreader/findfile.c
@@ -1,0 +1,74 @@
+/*
+  Copyright (c) 2020 Sascha Steinbiss <sascha@steinbiss.name>
+
+  Permission to use, copy, modify, and distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "findfile.h"
+#include "core/fileutils_api.h"
+#include "core/compat_api.h"
+
+int gth_find_file(const char *filename, const char *envname,
+                  const char *dirname, GtStr *out, GtError *err)
+{
+  int had_err = 0;
+  const char **defaultpath;
+  static const char *defaultpaths[] = {
+    "/usr/share/genomethreader",
+    "/usr/local/share/genomethreader",
+    "/usr/lib/genomethreader",
+    "/usr/local/lib/genomethreader",
+    NULL
+  };
+
+  gt_str_reset(out);
+  /* check in directory given by envname */
+  if (getenv(envname)) {
+    gt_str_append_cstr(out, getenv(envname));
+    gt_str_append_char(out, GT_PATH_SEPARATOR);
+    gt_str_append_cstr(out, filename);
+    if (gt_file_exists(gt_str_get(out))) {
+      return 0;
+    }
+  }
+
+  /* check for file relative to binary */
+  gt_str_reset(out);
+  had_err = gt_file_find_exec_in_path(out, gt_error_get_progname(err), NULL);
+  if (!had_err) {
+    gt_str_append_char(out, GT_PATH_SEPARATOR);
+    gt_str_append_cstr(out, dirname);
+    gt_str_append_char(out, GT_PATH_SEPARATOR);
+    gt_str_append_cstr(out, filename);
+    if (gt_file_exists(gt_str_get(out))) {
+      return 0;
+    }
+  }
+
+  /* check for file in set of default paths */
+  for (defaultpath = defaultpaths; *defaultpath; defaultpath++) {
+    gt_str_reset(out);
+    gt_str_append_cstr(out, *defaultpath);
+    gt_str_append_char(out, GT_PATH_SEPARATOR);
+    gt_str_append_cstr(out, dirname);
+    gt_str_append_char(out, GT_PATH_SEPARATOR);
+    gt_str_append_cstr(out, filename);
+    if (gt_file_exists(gt_str_get(out))) {
+      return 0;
+    }
+  }
+
+  gt_error_set(err, "could not find file '%s' in any of the search paths",
+               filename);
+  return -1;
+}

--- a/src/libgenomethreader/findfile.h
+++ b/src/libgenomethreader/findfile.h
@@ -1,0 +1,26 @@
+/*
+  Copyright (c) 2020 Sascha Steinbiss <sascha@steinbiss.name>
+
+  Permission to use, copy, modify, and distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef GTH_FINDFILE_H
+#define GTH_FINDFILE_H
+
+#include "core/str_api.h"
+#include "core/error_api.h"
+
+int gth_find_file(const char *filename, const char *envname,
+                  const char *dirname, GtStr *out, GtError *err);
+
+#endif


### PR DESCRIPTION
This PR unifies the way that external resources (such as BSSMs, alphabet definitions, or score matrices) are obtained in GenomeThreader. In the proposed approach, the following chain of locations will be searched for the file in question, in order:

- the value of the corresponding environment variable, e.g. `GTHDATADIR` or `GTHBSSMDIR`
- if the file was not found there, the `gthdata` or `bssm` subdirectories of the directory where the `gth` executable resides
- finally, the `gthdata` or `bssm` subdirectories of the system wide locations `/usr/share/genomethreader`, `/usr/local/share/genomethreader`, `/usr/lib/genomethreader` and `/usr/local/lib/genomethreader`.

The latter one is new because in system-wide installation situations, `gth` is in `/usr/bin` but the FHS disallows subdirectories there. Also, one cannot always assume that environment variables are set by default.

In general, this approach mirrors what is already done in  GenomeTools.