### PR TITLE
move genomethreader.org to a different server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006-2015 Gordon Gremme <gordon@gremme.org>
+# Copyright (c) 2006-2020 Gordon Gremme <gordon@gremme.org>
 # Copyright (c) 2006-2008 Center for Bioinformatics, University of Hamburg
 #
 # Permission to use, copy, modify, and distribute this software for any
@@ -145,8 +145,8 @@ else
   GTH_CPPFLAGS += -DNOLICENSEMANAGER
 endif
 
-SERVER=gordon@genomethreader.org
-WWWBASEDIR=/var/www/servers
+SERVER=stronghold
+WWWBASEDIR=/var/www/htdocs
 
 # process arguments
 ifeq ($(assert),no)
@@ -469,7 +469,7 @@ release:
 
 installwww:
 # install genomethreader.org website
-	rsync -rv www/genomethreader.org/ $(SERVER):$(WWWBASEDIR)/genomethreader.org
+	rsync -rv --delete www/genomethreader.org/htdocs/ $(SERVER):$(WWWBASEDIR)/genomethreader.org
 
 push:
 	git push origin master

--- a/www/genomethreader.org/htdocs/distributions/.htaccess
+++ b/www/genomethreader.org/htdocs/distributions/.htaccess
@@ -1,4 +1,0 @@
-AuthType Basic
-AuthName "Download GenomeThreader"
-AuthUserFile htdocs/distributions/.htpasswd
-Require valid-user

--- a/www/genomethreader.org/htdocs/download.html
+++ b/www/genomethreader.org/htdocs/download.html
@@ -49,17 +49,5 @@ purpose, are hereby excluded.
 <a href="mailto:gordon@gremme.org">Gordon Gremme</a>.
 Last update: 2020-01-11</div>
 
-<!-- Piwik -->
-<script type="text/javascript">
-var pkBaseURL = "https://zenlicensemanager.com/piwik/";
-document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
-</script><script type="text/javascript">
-try {
-var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", 4);
-piwikTracker.trackPageView();
-piwikTracker.enableLinkTracking();
-} catch( err ) {}
-</script><noscript><p><img src="https://zenlicensemanager.com/piwik/piwik.php?idsite=4" style="border:0" alt="" /></p></noscript>
-<!-- End Piwik Tracking Tag -->
 </body>
 </html>

--- a/www/genomethreader.org/htdocs/faq.html
+++ b/www/genomethreader.org/htdocs/faq.html
@@ -121,18 +121,5 @@ Copyright &copy; 2003-2016 <a href="mailto:gordon@gremme.org">
 Gordon Gremme</a>. Last update: 2016-09-20
 </div>
 
-<!-- Piwik -->
-<script type="text/javascript">
-var pkBaseURL = "https://zenlicensemanager.com/piwik/";
-document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
-</script><script type="text/javascript">
-try {
-var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", 4);
-piwikTracker.trackPageView();
-piwikTracker.enableLinkTracking();
-} catch( err ) {}
-</script><noscript><p><img src="https://zenlicensemanager.com/piwik/piwik.php?idsite=4" style="border:0" alt="" /></p></noscript>
-<!-- End Piwik Tracking Tag -->
-
 </body>
 </html>

--- a/www/genomethreader.org/htdocs/gthcases/softeng.html
+++ b/www/genomethreader.org/htdocs/gthcases/softeng.html
@@ -67,18 +67,5 @@
 
 <p>Back to <a href="../index.html">main page</a></p>
 
-<!-- Piwik -->
-<script type="text/javascript">
-var pkBaseURL = "https://zenlicensemanager.com/piwik/";
-document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
-</script><script type="text/javascript">
-try {
-var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", 4);
-piwikTracker.trackPageView();
-piwikTracker.enableLinkTracking();
-} catch( err ) {}
-</script><noscript><p><img src="https://zenlicensemanager.com/piwik/piwik.php?idsite=4" style="border:0" alt="" /></p></noscript>
-<!-- End Piwik Tracking Tag -->
-
 </body>
 </html>

--- a/www/genomethreader.org/htdocs/index.html
+++ b/www/genomethreader.org/htdocs/index.html
@@ -694,20 +694,6 @@ following dissertation:
   </li>
 </ul>
 <div id="footer">
-Copyright &copy; 2003-2018 <a href="mailto:gordon@gremme.org">
-Gordon Gremme</a>. Last update: 2018-02-07
+Copyright &copy; 2003-2020 <a href="mailto:gordon@gremme.org">
+Gordon Gremme</a>. Last update: 2020-09-04
 </div>
-<!-- Piwik -->
-<script type="text/javascript">
-var pkBaseURL = "https://zenlicensemanager.com/piwik/";
-document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
-</script><script type="text/javascript">
-try {
-var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", 4);
-piwikTracker.trackPageView();
-piwikTracker.enableLinkTracking();
-} catch( err ) {}
-</script><noscript><p><img src="https://zenlicensemanager.com/piwik/piwik.php?idsite=4" style="border:0" alt="" /></p></noscript>
-<!-- End Piwik Tracking Tag -->
-</body>
-</html>

--- a/www/genomethreader.org/htdocs/xml2html.rb
+++ b/www/genomethreader.org/htdocs/xml2html.rb
@@ -329,23 +329,6 @@ Gordon Gremme</a>. Last update: #{today}
 </div>
 FOOTER
 
-puts <<'FOOTER'
-<!-- Piwik -->
-<script type="text/javascript">
-var pkBaseURL = "https://zenlicensemanager.com/piwik/";
-document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
-</script><script type="text/javascript">
-try {
-var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", 4);
-piwikTracker.trackPageView();
-piwikTracker.enableLinkTracking();
-} catch( err ) {}
-</script><noscript><p><img src="https://zenlicensemanager.com/piwik/piwik.php?idsite=4" style="border:0" alt="" /></p></noscript>
-<!-- End Piwik Tracking Tag -->
-</body>
-</html>
-FOOTER
-
 totalcitations = 0
 cite_stat.sort.each do |k,v|
   totalcitations += v


### PR DESCRIPTION
The genomethreader.org website has been moved to a different server.
Update 'installwww' target accordingly and remove superfluous file.

The Piwik tracking code has been removed.